### PR TITLE
Fix URL for instance device snapshot

### DIFF
--- a/frontend/src/api/devices.js
+++ b/frontend/src/api/devices.js
@@ -116,7 +116,8 @@ const createSnapshot = async (device, options) => {
         description: options.description, // description of the snapshot
         setAsTarget: options.setAsTarget // set the snapshot as the new target for all devices
     }
-    return client.post(`/api/v1/devices/${deviceId}/snapshots`, data).then(res => {
+    const url = ownerType === 'application' ? `/api/v1/devices/${deviceId}/snapshots` : `/api/v1/devices/${deviceId}/snapshot`
+    return client.post(url, data).then(res => {
         const props = {
             ownerType,
             ownerId: ownerType === 'instance' ? instanceId : applicationId,


### PR DESCRIPTION
## Description

Corrects API call for instance snapshot

## Related Issue(s)

1.12 release issue

## Checklist

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

