### PR TITLE
Fix Pipeline Issue where "Create New Snapshot" results in error

### DIFF
--- a/frontend/src/components/pipelines/Stage.vue
+++ b/frontend/src/components/pipelines/Stage.vue
@@ -149,7 +149,7 @@ export default {
             if (!target) {
                 Alerts.emit(
                     `Unable to find configured target for stage "${this.stage.name}".`,
-                    'error'
+                    'warning'
                 )
             }
 
@@ -179,9 +179,10 @@ export default {
             this.$emit('stage-deploy-starting')
 
             try {
-                await PipelineAPI.deployPipelineStage(this.pipeline.id, this.stage.id, sourceSnapshot.id)
+                // sourceSnapshot can be undefined if "create new snapshot" was chosen
+                await PipelineAPI.deployPipelineStage(this.pipeline.id, this.stage.id, sourceSnapshot?.id)
             } catch (error) {
-                Alerts.emit(error.message, 'error')
+                Alerts.emit(error.message, 'warning')
                 return
             }
 

--- a/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
+++ b/test/e2e/frontend/cypress/tests-ee/applications/pipelines.spec.js
@@ -166,6 +166,95 @@ describe('FlowForge - Application - DevOps Pipelines', () => {
         })
     })
 
+    it('can push from one stage to another, creating a new snapshot', () => {
+        cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
+        cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')
+
+        /// Create stages ready to push between
+        cy.visit(`/application/${application.id}/pipelines`)
+        cy.wait('@getPipelines')
+
+        const PIPELINE_NAME = `My New Pipeline - ${Math.random().toString(36).substring(2, 7)}`
+
+        // Add pipeline
+        cy.get('[data-action="pipeline-add"]').click()
+        cy.get('[data-form="pipeline-form"]').should('be.visible')
+
+        cy.get('[data-form="pipeline-name"] input').type(PIPELINE_NAME)
+        cy.get('[data-action="create-pipeline"]').click()
+
+        cy.wait('@createPipeline')
+
+        // Add stage 1
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.get('[data-action="add-stage"]').click()
+        })
+
+        cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 1')
+
+        // Select Instance for Stage 1
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+        // Select "Create new Snapshot"
+        cy.get('[data-form="stage-action"] .ff-dropdown').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:first').click() // prompt
+
+        cy.get('[data-action="add-stage"]').click()
+
+        // Add stage 2
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.get('[data-action="add-stage"]').click()
+        })
+
+        cy.get('[data-form="stage-name"] input[type="text"]').type('Stage 2')
+
+        cy.get('[data-form="stage-instance"] .ff-dropdown').click()
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-instance"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+        cy.get('[data-form="stage-action"] .ff-dropdown').click()
+        cy.get('[data-form="stage-action"] .ff-dropdown-options').should('be.visible')
+        cy.get('[data-form="stage-action"] .ff-dropdown-options > .ff-dropdown-option:first').click()
+
+        cy.get('[data-action="add-stage"]').click()
+
+        /// Push from stage 1 to stage 2
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.get('[data-el="ff-pipeline-stage"]:contains("Stage 1")').within(() => {
+                cy.get('[data-action="stage-run"]').click()
+            })
+        })
+
+        cy.get('[data-el="deploy-stage-dialog"].ff-dialog-container--open').should('be.visible')
+        cy.get('[data-el="deploy-stage-dialog"].ff-dialog-container--open').within(() => {
+            // confirm push
+
+            /* eslint-disable cypress/require-data-selectors */
+            cy.get('button.ff-btn.ff-btn--primary').click()
+            /* eslint-enable */
+        })
+
+        // Tidy Up
+        cy.get(`[data-el="pipelines-list"] [data-el="pipeline-row"]:contains("${PIPELINE_NAME}")`).within(() => {
+            cy.contains('Stage 1')
+            cy.contains('Stage 2')
+
+            cy.get('[data-action="delete-pipeline"]').click()
+        })
+
+        cy.get('[data-el="platform-dialog"]')
+            .should('be.visible')
+            .within(() => {
+                /* eslint-disable cypress/require-data-selectors */
+                cy.get('.ff-dialog-header').contains('Delete Pipeline')
+                cy.get('button.ff-btn.ff-btn--danger').click()
+                /* eslint-enable */
+            })
+    })
+
     it('can push from one stage to another, prompting for snapshot', () => {
         cy.intercept('GET', '/api/v1/applications/*/pipelines').as('getPipelines')
         cy.intercept('POST', '/api/v1/pipelines').as('createPipeline')


### PR DESCRIPTION
## Description

- Fixes regressions preventing Instance to Instance pushing within a pipeline when a "Create New Snapshot" option is configured.
- Also fixed use of 'error' on the Alert type to be 'warning'.

## Related Issue(s)

https://github.com/FlowFuse/flowforge/pull/2818

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->